### PR TITLE
global-replicator - set max-parallel to 1

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       fail-fast: false  # false to run all, true to fail entire job if any fail
-      max-parallel: 2  # jobs fail submitting PRs if run too fast
+      max-parallel: 1  # jobs fail submitting PRs if run too fast
       matrix:
         include:
         - job_name: 'replicate workflows'


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- set max-parallel to 1 for global-replicator workflow
  - The workflow can fail to create PRs when running too many jobs in parallel


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
