### PR TITLE
correct `contains` expression

### DIFF
--- a/.github/workflows/autoupdate-labeler.yml
+++ b/.github/workflows/autoupdate-labeler.yml
@@ -15,12 +15,12 @@ jobs:
   label_pr:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      contains('] I want maintainers to keep my branch updated\r', github.event.pull_request.body)
+      contains(github.event.pull_request.body, '] I want maintainers to keep my branch updated\r')
     runs-on: ubuntu-latest
     steps:
       - name: Label autoupdate
         if: >-
-          contains('\n- [x] I want maintainers to keep my branch updated\r', github.event.pull_request.body) == true
+          contains(github.event.pull_request.body, '\n- [x] I want maintainers to keep my branch updated\r') == true
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Unlabel autoupdate
         if: >-
-          contains('\n- [x] I want maintainers to keep my branch updated\r', github.event.pull_request.body) == false
+          contains(github.event.pull_request.body, '\n- [x] I want maintainers to keep my branch updated\r') == false
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR should fix the autoupdate labeler. The variables for the `contains` expression were reversed according to https://docs.github.com/en/actions/learn-github-actions/expressions#contains


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
