### PR TITLE
use `fromJson` expression

### DIFF
--- a/.github/workflows/autoupdate-labeler.yml
+++ b/.github/workflows/autoupdate-labeler.yml
@@ -15,12 +15,13 @@ jobs:
   label_pr:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      contains(github.event.pull_request.body, '] I want maintainers to keep my branch updated\r')
+      contains(github.event.pull_request.body, fromJSON('"] I want maintainers to keep my branch updated\r"'))
     runs-on: ubuntu-latest
     steps:
       - name: Label autoupdate
         if: >-
-          contains(github.event.pull_request.body, '\n- [x] I want maintainers to keep my branch updated\r') == true
+          contains(github.event.pull_request.body,
+            fromJSON('"\n- [x] I want maintainers to keep my branch updated\r"')) == true
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}
@@ -34,14 +35,16 @@ jobs:
 
       - name: Unlabel autoupdate
         if: >-
-          contains(github.event.pull_request.body, '\n- [x] I want maintainers to keep my branch updated\r') == false
+          contains(github.event.pull_request.body,
+            fromJSON('"\n- [x] I want maintainers to keep my branch updated\r"')) == false &&
+          contains(github.event.pull_request.labels.*.name, 'autoupdate')
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}
           script: |
-            github.rest.issues.addLabels({
+            github.rest.issues.removeLabel({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'autoupdate'
+              name: ['autoupdate']
             })


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use `fromJson` expression to correct issue with `\r` and `\n` in workflow. See https://stackoverflow.com/questions/72277477/how-to-use-escape-sequences-in-strings-in-github-actions-expressions for more details.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
