### PR TITLE
replicate global workflows to forked repos

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -38,7 +38,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: ''
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
           - job_name: 'replicate python'
@@ -50,7 +50,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: 'python'
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
           - job_name: 'replicate docker'
@@ -61,7 +61,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: 'docker'
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
           - job_name: 'replicate cpp'
@@ -73,7 +73,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: 'cpp'
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
           - job_name: 'custom issues'
@@ -84,7 +84,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: 'replicator-custom-issues'
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
           - job_name: 'release notifier'
@@ -95,7 +95,7 @@ jobs:
             repos_to_ignore: ''
             topics_to_include: 'replicator-release-notifications'
             exclude_private: false
-            exclude_forked: true
+            exclude_forked: false
             branches: '^nightly$'
             destination: ''
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- replicate global workflows to forked repos (excluding specific repos)
  - This is required to better maintain the `archlinux-package-action` locally.
  - Only forked repos with a `nightly` branch will get replicated files.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
