### PR TITLE
fix autoupdate labeler for forks

### DIFF
--- a/.github/workflows/autoupdate-labeler.yml
+++ b/.github/workflows/autoupdate-labeler.yml
@@ -6,22 +6,46 @@
 name: Label PR autoupdate
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - edited
       - opened
+      - synchronize
+  pull_request_review:
+    types:
+      - edited
+      - submitted
 
 jobs:
   label_pr:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      contains(github.event.pull_request.body, fromJSON('"] I want maintainers to keep my branch updated\r"'))
+      contains(github.event.pull_request.body, fromJSON('"] I want maintainers to keep my branch updated"'))
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Check if member
+        id: org_member
+        run: |
+          status="true"
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            /orgs/${{ github.repository_owner }}/members/${{ github.actor }} || status="false"
+
+          echo "result=${status}" >> $GITHUB_OUTPUT
+
       - name: Label autoupdate
         if: >-
+          steps.org_member.outputs.result == 'true' &&
+          contains(github.event.pull_request.labels.*.name, 'autoupdate') == false &&
           contains(github.event.pull_request.body,
-            fromJSON('"\n- [x] I want maintainers to keep my branch updated\r"')) == true
+            fromJSON('"\n- [x] I want maintainers to keep my branch updated"')) == true &&
+          (
+            (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+            (github.event_name == 'pull_request')
+          )
+
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}
@@ -35,9 +59,15 @@ jobs:
 
       - name: Unlabel autoupdate
         if: >-
-          contains(github.event.pull_request.body,
-            fromJSON('"\n- [x] I want maintainers to keep my branch updated\r"')) == false &&
-          contains(github.event.pull_request.labels.*.name, 'autoupdate')
+          contains(github.event.pull_request.labels.*.name, 'autoupdate') &&
+          github.event_name == 'pull_request' &&
+          (
+            (github.event.action == 'synchronize' && steps.org_member.outputs.result == 'false') ||
+            (steps.org_member.outputs.result == 'true' &&
+            contains(github.event.pull_request.body,
+              fromJSON('"\n- [x] I want maintainers to keep my branch updated"')) == false
+            )
+          )
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GH_BOT_TOKEN }}

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -3,8 +3,9 @@
 # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
 # the above-mentioned repo.
 
-# This workflow is designed to work with:
-# - automerge workflows
+# This workflow is designed to work with the following workflows:
+# - automerge
+# - autoupdate-labeler
 
 # It uses GitHub Action that auto-updates pull requests branches, when changes are pushed to their destination branch.
 # Auto-updating to the latest destination branch works only in the context of upstream repo and not forks.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- change to `pull_request_target` trigger so the action can run without approval
- label is now added when a PR is approved by an organization member
- label is now removed when PR is synchronized and actor is not an organization member
- for organization members, the label is added/removed on additional events, such as editing the PR body (e.g. checking or unchecking a checkbox).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
