### PR TITLE
Fix/autoupdate and automerge

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -51,7 +51,7 @@ jobs:
           BASE_BRANCHES: nightly
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
           GITHUB_LOGIN: ${{ secrets.GH_BOT_NAME }}
-          MERGE_LABELS: ""
+          MERGE_LABELS: "!dependencies"
           MERGE_METHOD: "squash"
           MERGE_COMMIT_MESSAGE: "{pullRequest.title} (#{pullRequest.number})"
           MERGE_DELETE_BRANCH: true

--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -36,11 +36,17 @@ jobs:
   dependabot-rebase:
     name: Dependabot Rebase
     if: >-
-      startsWith(github.repository, 'LizardByte/') &&
-      contains(github.event.pull_request.labels.*.name, 'central_dependency') == false
+      startsWith(github.repository, 'LizardByte/')
     runs-on: ubuntu-latest
     steps:
+      - name: check labels
+        id: label
+        run: |
+          echo "central_dep=${{ contains(github.event.pull_request.labels.*.name, 'central_dependency') }}" \
+            >> $GITHUB_OUTPUT
+
       - name: rebase
+        if: ${{ steps.label.outputs.central_dep == false }}
         uses: "bbeesley/gha-auto-dependabot-rebase@v1.2.0"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- do not automerge PRs labeled `dependencies`
- do not auto rebase PRs labeled `central_dependency`


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #150 
- Fixes #152 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
