### PR TITLE
remove dependabot rebsae condition

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -39,14 +39,7 @@ jobs:
       startsWith(github.repository, 'LizardByte/')
     runs-on: ubuntu-latest
     steps:
-      - name: check labels
-        id: label
-        run: |
-          echo "central_dep=${{ contains(github.event.pull_request.labels.*.name, 'central_dependency') }}" \
-            >> $GITHUB_OUTPUT
-
       - name: rebase
-        if: ${{ steps.label.outputs.central_dep == 'false' }}
         uses: "bbeesley/gha-auto-dependabot-rebase@v1.2.0"
         env:
           GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
The github context to check for the `central_dependency` label runs in the context of the push, unfortunately not in the context of the dependabot PR.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I want maintainers to keep my branch updated
