### PR TITLE
pin flake8 version

### DIFF
--- a/.github/workflows/python-flake8.yml
+++ b/.github/workflows/python-flake8.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools flake8
+          # pin flake8 before v6.0.0 due to removal of support for type comments (required for Python 2.7 type hints)
+          python -m pip install --upgrade pip setuptools "flake8<6"
 
       - name: Test with flake8
         run: |


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
flake8 v6.0.0 removed support for type comments which are required for Python 2.7 type hints. This is a temporary fix to allow workflows to continue working until an alternate solution is found.

### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves #131 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
