### PR TITLE
docker build dependent on event type

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -11,6 +11,9 @@
 # `# platforms: `
 #    Comma separated list of platforms, i.e. `# platforms: linux/386,linux/amd64`. Docker platforms can alternatively
 #    be listed in a file named `.docker_platforms`.
+# `# platforms_pr: `
+#    Comma separated list of platforms to run for PR events, i.e. `# platforms_pr: linux/amd64`. This will take
+#    precedence over the `# platforms: ` directive.
 # `# artifacts: `
 #    `true` to build in two steps, stopping at `artifacts` build stage and extracting the image from there to the
 #    GitHub runner.
@@ -202,8 +205,7 @@ jobs:
           # get branch name
           BRANCH=${GITHUB_HEAD_REF}
 
-          if [ -z "$BRANCH" ]
-          then
+          if [ -z "$BRANCH" ]; then
             echo "This is a PUSH event"
             BRANCH=${{ github.ref_name }}
           fi
@@ -237,6 +239,19 @@ jobs:
 
           # parse custom directives out of dockerfile
           # try to get the platforms from the dockerfile custom directive, i.e. `# platforms: xxx,yyy`
+          # directives for PR event, i.e. not push event
+          if [[ ${PUSH} == "false" ]]; then
+            while read -r line; do
+              if [[ $line == "# platforms_pr: "* && $PLATFORMS == "" ]]; then
+                # echo the line and use `sed` to remove the custom directive
+                PLATFORMS=$(echo -e "$line" | sed 's/# platforms_pr: //')
+              elif [[ $PLATFORMS != "" ]]; then
+                # break while loop once all custom "PR" event directives are found
+                break
+              fi
+            done <"${{ matrix.dockerfile }}"
+          fi
+          # directives for all events... above directives will not be parsed if they were already found
           while read -r line; do
             if [[ $line == "# platforms: "* && $PLATFORMS == "" ]]; then
               # echo the line and use `sed` to remove the custom directive


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Docker build dependent on event type. This can alleviate issues with slow builds for arm64 on PR events.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
