### PR TITLE
disable dependabot auto rebase

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -9,7 +9,7 @@
 
 # It uses an action that auto-updates pull requests branches, when changes are pushed to their destination branch.
 # Auto-updating to the latest destination branch works only in the context of upstream repo and not forks.
-# Dependabot PRs are updated by an action that comments `@depdenabot rebase` on dependabot PRs.
+# Dependabot PRs are updated by an action that comments `@depdenabot rebase` on dependabot PRs. (disabled)
 
 name: autoupdate
 
@@ -34,13 +34,18 @@ jobs:
           PR_READY_STATE: "all"
           MERGE_CONFLICT_ACTION: "fail"
 
-  dependabot-rebase:
-    name: Dependabot Rebase
-    if: >-
-      startsWith(github.repository, 'LizardByte/')
-    runs-on: ubuntu-latest
-    steps:
-      - name: rebase
-        uses: "bbeesley/gha-auto-dependabot-rebase@v1.3.18"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+# Disabled due to:
+# - no major version tag, resulting in constant nagging to update this action
+# - additionally, the code is sketchy, 16k+ lines of code?
+# https://github.com/bbeesley/gha-auto-dependabot-rebase/blob/main/dist/main.cjs
+#
+#  dependabot-rebase:
+#    name: Dependabot Rebase
+#    if: >-
+#      startsWith(github.repository, 'LizardByte/')
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: rebase
+#        uses: "bbeesley/gha-auto-dependabot-rebase@v1.3.18"
+#        env:
+#          GITHUB_TOKEN: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Disable dependabot auto rebase

Disabled due to:
- no major version tag, resulting in constant nagging to update this action (https://github.com/bbeesley/gha-auto-dependabot-rebase/issues/262)
- additionally, the code is sketchy, 16k+ lines of code? (https://github.com/bbeesley/gha-auto-dependabot-rebase/blob/main/dist/main.cjs)


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
