### PR TITLE
qodana: fix dispatch permissions

### DIFF
--- a/.github/workflows/ci-qodana.yml
+++ b/.github/workflows/ci-qodana.yml
@@ -20,6 +20,8 @@ concurrency:
 jobs:
   qodana_initial_check:
     name: Qodana Initial Check
+    permissions:
+      actions: write  # required to use workflow dispatch on fork PRs
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -235,6 +237,8 @@ jobs:
     needs: [qodana_initial_check, qodana]
     runs-on: ubuntu-latest
     name: Dispatch Qodana
+    permissions:
+      actions: write  # required to use workflow dispatch on fork PRs
     if: ${{ needs.qodana_initial_check.outputs.files != '' }}
     steps:
       - name: Setup qodana publish inputs


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fix permissions for qodana dispatch events, when running from fork PRs.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
