### PR TITLE
style(clang-format): add option to ignore directories

### DIFF
--- a/.github/workflows/cpp-lint.yml
+++ b/.github/workflows/cpp-lint.yml
@@ -26,20 +26,38 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Find cpp files
-        id: cpp_files
+        id: find_files
         run: |
-          cpp_files=$(find . -type f -iname "*.cpp" -o -iname "*.h" -o -iname "*.m" -o -iname "*.mm")
+          # find files
+          found_files=$(find . -type f -iname "*.cpp" -o -iname "*.h" -o -iname "*.m" -o -iname "*.mm")
+          ignore_files=$(find . -type f -iname ".clang-format-ignore")
 
-          echo "found cpp files: ${cpp_files}"
+          # Loop through each C++ file
+          for file in $found_files; do
+            for ignore_file in $ignore_files; do
+              ignore_directory=$(dirname "$ignore_file")
+              # if directory of ignore_file is beginning of file
+              if [[ "$file" == "$ignore_directory"* ]]; then
+                echo "ignoring file: ${file}"
+                found_files="${found_files//${file}/}"
+                break 1
+              fi
+            done
+          done
+
+          # remove empty lines
+          found_files=$(echo "$found_files" | sed '/^\s*$/d')
+
+          echo "found cpp files: ${found_files}"
 
           # do not quote to keep this as a single line
-          echo cpp_files=${cpp_files} >> $GITHUB_OUTPUT
+          echo found_files=${found_files} >> $GITHUB_OUTPUT
 
       - name: Clang format lint
-        if: ${{ steps.cpp_files.outputs.cpp_files }}
-        uses: DoozyX/clang-format-lint-action@v0.16
+        if: ${{ steps.find_files.outputs.found_files }}
+        uses: DoozyX/clang-format-lint-action@v0.15
         with:
-          source: ${{ steps.cpp_files.outputs.cpp_files }}
+          source: ${{ steps.find_files.outputs.found_files }}
           extensions: 'cpp,h,m,mm'
           clangFormatVersion: 15
           style: file
@@ -50,7 +68,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: clang-format-fixes
-          path: ${{ steps.cpp_files.outputs.cpp_files }}
+          path: ${{ steps.find_files.outputs.found_files }}
 
   cmake-lint:
     name: CMake Lint
@@ -70,15 +88,33 @@ jobs:
           python -m pip install --upgrade pip setuptools cmakelang
 
       - name: Find cmake files
-        id: cmake_files
+        id: find_files
         run: |
-          cmake_files=$(find . -type f -iname "CMakeLists.txt" -o -iname "*.cmake")
+          # find files
+          found_files=$(find . -type f -iname "CMakeLists.txt" -o -iname "*.cmake")
+          ignore_files=$(find . -type f -iname ".cmake-lint-ignore")
 
-          echo "found cmake files: ${cmake_files}"
+          # Loop through each C++ file
+          for file in $found_files; do
+            for ignore_file in $ignore_files; do
+              ignore_directory=$(dirname "$ignore_file")
+              # if directory of ignore_file is beginning of file
+              if [[ "$file" == "$ignore_directory"* ]]; then
+                echo "ignoring file: ${file}"
+                found_files="${found_files//${file}/}"
+                break 1
+              fi
+            done
+          done
+
+          # remove empty lines
+          found_files=$(echo "$found_files" | sed '/^\s*$/d')
+
+          echo "found cmake files: ${found_files}"
 
           # do not quote to keep this as a single line
-          echo cmake_files=${cmake_files} >> $GITHUB_OUTPUT
+          echo found_files=${found_files} >> $GITHUB_OUTPUT
 
       - name: Test with cmake-lint
         run: |
-          cmake-lint --line-width 120 --tab-size 4 ${{ steps.cmake_files.outputs.cmake_files }}
+          cmake-lint --line-width 120 --tab-size 4 ${{ steps.find_files.outputs.found_files }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds the ability to ignore specified directories for clang format.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
