### PR TITLE
fix(codeql): detect cpp and csharp

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,10 @@ on:
   schedule:
     - cron: '00 12 * * 0'  # every Sunday at 12:00 UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   languages:
     name: Get language matrix
@@ -35,6 +39,8 @@ jobs:
             const supported_languages = ['cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby', 'swift']
 
             const remap_languages = {
+              'c++': 'cpp',
+              'c#': 'csharp',
               'kotlin': 'java',
               'typescript': 'javascript',
             }
@@ -45,7 +51,7 @@ jobs:
               "include": []
             }
 
-            for (const [key, value] of Object.entries(response.data)) {
+            for (let [key, value] of Object.entries(response.data)) {
               // remap language
               if (remap_languages[key.toLowerCase()]) {
                 console.log(`Remapping language: ${key} to ${remap_languages[key.toLowerCase()]}`)
@@ -95,6 +101,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
@@ -109,8 +117,17 @@ jobs:
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
           # queries: security-extended,security-and-quality
 
+      # Pre autobuild
+      # create a file named .codeql-prebuild-${{ matrix.language }}.sh in the root of your repository
+      - name: Prebuild
+        run: |
+          # check if .qodeql-prebuild-${{ matrix.language }}.sh exists
+          if [ -f "./.codeql-prebuild-${{ matrix.language }}.sh" ]; then
+            echo "Running .codeql-prebuild-${{ matrix.language }}.sh"
+            ./.codeql-prebuild-${{ matrix.language }}.sh
+          fi
+
       # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-      # TODO: If this step fails, then we need to create a method to build the project using an automated method.
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2
 


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Properly detect C++ and C# languages, by remapping them to the CodeQL equivalent of `cpp` and `csharp`. Additionally:
- adds prebuild mechanism for when autobuild fails
- adds workflow concurrency
- fixes issue with javascript variable


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
