### PR TITLE
fix: use Windows style PATH for Python 2.7

### DIFF
--- a/actions/setup_python2/action.yml
+++ b/actions/setup_python2/action.yml
@@ -55,6 +55,7 @@ runs:
 
           # set venv path
           venv_base_path="/c/tmp/python27/venv"
+          venv_base_path_windows="C:\\tmp\\python27\\venv"
           venv_dir="Scripts"
         elif [[ "${{ runner.os }}" == "Linux" ]]; then
           sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
@@ -86,8 +87,12 @@ runs:
         python -m pip --no-python-version-warning --disable-pip-version-check install --upgrade pip setuptools
 
         # update the path environment, so the next steps can use the venv
-        # required to use the bash shell
-        echo "${venv_base_path}/${venv_dir}" >> $GITHUB_PATH
+        # required to use the shell
+        if [[ "${{ runner.os }}" == "Windows" ]]; then
+            echo "${venv_base_path_windows}\\${venv_dir}" >> $GITHUB_PATH
+        else
+            echo "${venv_base_path}/${venv_dir}" >> $GITHUB_PATH
+        fi
 
         # show python version
         echo "Python venv version:"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Put Windows style path on PATH environment for Windows OS.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
