### PR TITLE
ci: use default branch for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,6 @@ updates:
     schedule:
       interval: "daily"
       time: "08:00"
-    target-branch: "nightly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "github-actions"
@@ -18,7 +17,6 @@ updates:
     schedule:
       interval: "daily"
       time: "08:30"
-    target-branch: "nightly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "npm"
@@ -26,7 +24,6 @@ updates:
     schedule:
       interval: "daily"
       time: "09:00"
-    target-branch: "nightly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "nuget"
@@ -34,7 +31,6 @@ updates:
     schedule:
       interval: "daily"
       time: "09:30"
-    target-branch: "nightly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "pip"
@@ -42,7 +38,6 @@ updates:
     schedule:
       interval: "daily"
       time: "10:00"
-    target-branch: "nightly"
     open-pull-requests-limit: 10
 
   - package-ecosystem: "gitsubmodule"
@@ -50,5 +45,4 @@ updates:
     schedule:
       interval: "daily"
       time: "10:30"
-    target-branch: "nightly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Before merging this, I need to update the default branch on nearly all repos in the org.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
