### PR TITLE
ci(replicator): use wait-for-jobs instead of max-parallel

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -23,10 +23,10 @@ jobs:
 
     strategy:
       fail-fast: false  # false to run all, true to fail entire job if any fail
-      max-parallel: 1  # jobs fail submitting PRs if run too fast
       matrix:
         include:
           - job_name: 'replicate workflows'
+            depends_on: ''
             patterns_to_ignore: ''
             patterns_to_include: >-
               .github/dependabot.yml,
@@ -53,6 +53,7 @@ jobs:
             exclude_forked: true
             destination: ''
           - job_name: 'replicate python'
+            depends_on: 'replicate workflows'
             patterns_to_ignore: ''
             patterns_to_include: >-
               .flake8,
@@ -65,6 +66,7 @@ jobs:
             exclude_forked: true
             destination: ''
           - job_name: 'replicate docker'
+            depends_on: 'replicate python'
             patterns_to_ignore: ''
             patterns_to_include: >-
               .github/workflows/ci-docker.yml
@@ -76,6 +78,7 @@ jobs:
             exclude_forked: true
             destination: ''
           - job_name: 'replicate cpp'
+            depends_on: 'replicate docker'
             patterns_to_ignore: ''
             patterns_to_include: >-
               .clang-format,
@@ -87,7 +90,8 @@ jobs:
             exclude_private: false
             exclude_forked: true
             destination: ''
-          - job_name: 'custom issues'
+          - job_name: 'replicate custom issues'
+            depends_on: 'replicate cpp'
             patterns_to_ignore: ''
             patterns_to_include: >-
               .github/ISSUE_TEMPLATE/config.yml
@@ -99,6 +103,7 @@ jobs:
             exclude_forked: true
             destination: ''
           - job_name: 'release notifier'
+            depends_on: 'replicate custom issues'
             patterns_to_ignore: ''
             patterns_to_include: >-
               .github/workflows/release-notifier.yml
@@ -115,6 +120,14 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      # replaced max-parallel: 1 with wait-for-jobs to ensure that all jobs are started
+      # we want all jobs started because once we push to the repos, all runners will be consumed
+      - name: Wait for previous job
+        if: ${{ matrix.depends_on != '' }}
+        uses: yogeshlonkar/wait-for-jobs@v0
+        with:
+          jobs: ${{ matrix.depends_on }}
 
       - name: Removing files
         if: ${{ matrix.patterns_to_remove != '' }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
When using max-parallel = 1, all the runners in the org are quickly consumed and we cannot update the PR branches fast enough... resulted in a lot of wasted runner minutes and time before it will continue in the matrix.

This change ensures all matrix jobs are started and the pushes will continue to happen.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
