### PR TITLE
feat: add renovate config

### DIFF
--- a/renovate-config.json
+++ b/renovate-config.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate onboarding preset for use with LizardByte's repos",
+  "extends": ["github>LizardByte/.github:renovate-config.json5"]
+}

--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -1,0 +1,33 @@
+{
+  // see https://docs.renovatebot.com/configuration-options
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "branchNameStrict": true,  // remove special characters from branch names
+  "configMigration": true,  // allow renovate to open PRs to update config
+  "description": "Default renovate configuration for LizardByte repositories",
+  "extends": [
+    "config:base"
+  ],
+  "dependencyDashboard": true,  // Creates an issue with a "dashboard" of dependencies
+  "dependencyDashboardLabels": [
+    "dependencies"
+  ],
+  "labels": [
+    "dependencies",
+    "{{category}}"
+  ],
+  "prConcurrentLimit": 10,
+  "rollbackPrs": true,  // create a rollback PR when a dependency is yanked
+  "schedule": [
+    "after 1am",
+    "before 6am"
+  ],
+  "semanticCommitScope": "deps",
+  "semanticCommitType": "build",
+  "semanticCommits": "enabled",
+  "timezone": "America/New_York",
+  "updatePinnedDependencies": true,
+  // beta features
+  "git-submodules": {
+    "enabled": true
+  }
+}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a reusable config for [renovate](https://docs.renovatebot.com).


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
