### PR TITLE
fix(renovate): set packageRules for LizardByte actions

### DIFF
--- a/renovate-config.json5
+++ b/renovate-config.json5
@@ -31,5 +31,14 @@
   // beta features
   "git-submodules": {
     "enabled": true
-  }
+  },
+  // package rules
+  "packageRules": [
+    {
+      // match LizardByte's GitHub actions
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^LizardByte/"],
+      "ignoreUnstable": false,  // renovate using semver to determine stability, which does not align with our tags
+    }
+  ]
 }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add package rules for LizardByte's GitHub actions, and allow renovate to update to "unstable" versions, since our tags do not match the standard.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
