### PR TITLE
fix(global-replicator): use commit message

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -49,7 +49,6 @@ jobs:
               qodana-dotnet.yaml,
               qodana-js.yaml,
               qodana-python.yaml
-            commit_message: 'ci: update global workflows'
             repos_to_ignore: ''
             topics_to_include: ''
             exclude_private: false
@@ -62,7 +61,6 @@ jobs:
               .flake8,
               .github/workflows/python-flake8.yml
             patterns_to_remove: ''
-            commit_message: 'ci: update global python'
             repos_to_ignore: ''
             topics_to_include: 'python'
             exclude_private: false
@@ -74,7 +72,6 @@ jobs:
             patterns_to_include: >-
               .github/workflows/ci-docker.yml
             patterns_to_remove: ''
-            commit_message: 'ci: update global docker'
             repos_to_ignore: ''
             topics_to_include: 'docker'
             exclude_private: false
@@ -87,7 +84,6 @@ jobs:
               .clang-format,
               .github/workflows/cpp-lint.yml
             patterns_to_remove: ''
-            commit_message: 'ci: update global cpp'
             repos_to_ignore: ''
             topics_to_include: 'cpp'
             exclude_private: false
@@ -99,7 +95,6 @@ jobs:
             patterns_to_include: >-
               .github/ISSUE_TEMPLATE/config.yml
             patterns_to_remove: ''
-            commit_message: 'ci: update issue templates'
             repos_to_ignore: ''
             topics_to_include: 'replicator-custom-issues'
             exclude_private: false
@@ -111,7 +106,6 @@ jobs:
             patterns_to_include: >-
               .github/workflows/release-notifier.yml
             patterns_to_remove: ''
-            commit_message: 'ci: update release notifier'
             repos_to_ignore: ''
             topics_to_include: 'replicator-release-notifications'
             exclude_private: false
@@ -141,7 +135,7 @@ jobs:
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
           patterns_to_ignore: ${{ matrix.patterns_to_ignore }}
           patterns_to_remove: ${{ matrix.patterns_to_remove }}
-          commit_message: ${{ matrix.commit_message }}
+          commit_message: 'chore: update global workflows'
           repos_to_ignore: ${{ matrix.repos_to_ignore }}
           topics_to_include: ${{ matrix.topics_to_include }}
           exclude_private: ${{ matrix.exclude_private }}
@@ -163,7 +157,7 @@ jobs:
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
           patterns_to_ignore: ${{ matrix.patterns_to_ignore }}
           patterns_to_include: ${{ matrix.patterns_to_include }}
-          commit_message: ${{ matrix.commit_message }}
+          commit_message: 'chore: update global workflows'
           repos_to_ignore: ${{ matrix.repos_to_ignore }}
           topics_to_include: ${{ matrix.topics_to_include }}
           exclude_private: ${{ matrix.exclude_private }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Since PRs take the first commit as the PR title, this PR adjusts the global replicator to use the same commit message for each job in the matrix.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
