### PR TITLE
docs: remove qodana guidelines

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,26 +111,6 @@ the repository. The following table shows the labels and the corresponding tests
    * - ``c++``
      - ``clang-format``, ``cmake-lint``
 
-Code Inspection Tests
-^^^^^^^^^^^^^^^^^^^^^
-We use `Qodana <https://www.jetbrains.com/qodana/>`_ to inspect our code for common issues. Qodana will run if the
-repository contains a ``qodana-<language>.yml`` file. The file contains the configuration for the inspection.
-The supported languages are:
-
-- ``dotnet``
-- ``go``
-- ``java``
-- ``js``
-- ``php``
-- ``python``
-
-We publish Qodana reports to our `qodana-reports <https://lizardbyte.github.io/qodana-reports>`_ page. To publish
-reports, the ``dispatcher.yml`` file should be present on the default branch of the repository. If the reports are not
-published, you can still view them through the workflow logs.
-
-Qodana also annotates the PR files with any new issues it finds. You can view these annotations in the `Files Changed`
-tab of the PR.
-
 Unit Testing
 ^^^^^^^^^^^^
 We strive to have comprehensive unit tests for our projects, but this is still a work in progress for some projects.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Remove Qodana guidelines.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
