### PR TITLE
feat(workflows): add workflow to patch missing releases

### DIFF
--- a/.github/workflows/patch_missing_releases.yml
+++ b/.github/workflows/patch_missing_releases.yml
@@ -1,0 +1,54 @@
+---
+# GitHub releases made by @LizardByte-bot were hidden from the GitHub UI and API endpoint `/releases`
+# on 1/23/2024. The releases can still be accessed at their own URL, and API endpoint.
+
+# It was discovered that the releases will re-appear if they are manually "edited".
+
+name: Patch Missing Releases
+on:
+  workflow_dispatch:
+
+jobs:
+  patch_missing_releases:
+    name: Patch Missing Releases
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Patch
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GH_BOT_TOKEN }}
+          script: |
+            // get all repos in the org
+            const repos_opts = github.rest.repos.listForOrg.endpoint.merge({
+              org: context.repo.owner,
+            })
+            const repos = await github.paginate(repos_opts)
+
+            // iterate over repos
+            for (const repo of repos.data) {
+              // tags still exist and they match releases
+              // get all tags for the repo
+              const tags_opts = github.rest.repos.listTags.endpoint.merge({
+                  owner: context.repo.owner,
+                  repo: repo.name
+              })
+              const tags = await github.paginate(tags_opts)
+
+              // iterate over tags
+              for (const tag of tags.data) {
+                // get release for tag
+                const release = await github.rest.repos.getReleaseByTag({
+                  owner: context.repo.owner,
+                  repo: repo.name,
+                  tag: tag.name
+                })
+
+                // edit the release (without making any changes)
+                await github.rest.repos.updateRelease({
+                    owner: context.repo.owner,
+                    repo: repo.name,
+                    release_id: release.data.id,
+                })
+              }
+            }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR adds a workflow that needs to be run manually. The purpose is to perform an "edit" with no actual changes on each release in the organization.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #311 


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
