### PR TITLE
fix(patch-releases): skip non existent releases

### DIFF
--- a/.github/workflows/patch_missing_releases.yml
+++ b/.github/workflows/patch_missing_releases.yml
@@ -48,18 +48,22 @@ jobs:
 
                 // get release for tag
                 console.log(`Getting release for tag: ${tag.name}`)
-                const release = await github.rest.repos.getReleaseByTag({
-                  owner: context.repo.owner,
-                  repo: repo.name,
-                  tag: tag.name
-                })
-
-                // edit the release (without making any changes)
-                console.log(`Editing release for tag: ${tag.name}`)
-                await github.rest.repos.updateRelease({
+                try {
+                  const release = await github.rest.repos.getReleaseByTag({
                     owner: context.repo.owner,
                     repo: repo.name,
-                    release_id: release.data.id,
-                })
+                    tag: tag.name
+                  })
+
+                  // edit the release (without making any changes)
+                  console.log(`Editing release for tag: ${tag.name}`)
+                  await github.rest.repos.updateRelease({
+                      owner: context.repo.owner,
+                      repo: repo.name,
+                      release_id: release.data.id,
+                  })
+                } catch (error) {
+                  console.log(`No release found for tag: ${tag.name}`)
+                }
               }
             }


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Skip releases that don't actually exist.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
