### PR TITLE
fix: only replicate update-changelog to release notification repos

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -73,7 +73,6 @@ jobs:
             .github/workflows/codeql.yml,
             .github/workflows/issues.yml,
             .github/workflows/issues-stale.yml,
-            .github/workflows/update-changelog.yml,
             .github/workflows/yaml-lint.yml
           commit_message: 'chore: update global workflows'
           repos_to_ignore: ''
@@ -168,7 +167,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Replicating files (release notifier)
+      - name: Replicating files (release/changelog workflows)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
           github_token: ${{ secrets.GH_BOT_TOKEN }}
@@ -176,10 +175,32 @@ jobs:
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
           patterns_to_ignore: ''
           patterns_to_include: >-
-            .github/workflows/release-notifier.yml
+            .github/workflows/release-notifier.yml,
+            .github/workflows/update-changelog.yml
           commit_message: 'chore: update global workflows'
           repos_to_ignore: ''
           topics_to_include: 'replicator-release-notifications'
+          exclude_private: false
+          exclude_forked: true
+          destination: ''
+          bot_branch_name: bot/update-files-from-global-repo
+
+      # todo: the following can be removed after it has run once
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Removing files (changelog workflows)
+        uses: derberg/manage-files-in-multiple-repositories@v2.1.0
+        with:
+          github_token: ${{ secrets.GH_BOT_TOKEN }}
+          committer_username: ${{ secrets.GH_BOT_NAME }}
+          committer_email: ${{ secrets.GH_BOT_EMAIL }}
+          patterns_to_ignore: ''
+          patterns_to_remove: >-
+            .github/workflows/update-changelog.yml
+          commit_message: 'chore: update global workflows'
+          repos_to_ignore: ''
+          topics_to_include: 'github-action'
           exclude_private: false
           exclude_forked: true
           destination: ''


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This is not necessary to have in every repo in the org.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
