### PR TITLE
fix: use correct logic in release notifier

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -9,15 +9,15 @@ name: Release Notifications
 
 on:
   release:
-    types: [published]
-    # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onevent_nametypes
+    types:
+      - released  # this triggers when a release is published, but does not include prereleases or drafts
 
 jobs:
   discord:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      not(github.event.release.prerelease) &&
-      not(github.event.release.draft)
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: discord
@@ -35,8 +35,8 @@ jobs:
   facebook_group:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      not(github.event.release.prerelease) &&
-      not(github.event.release.draft)
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: facebook-post-action
@@ -52,8 +52,8 @@ jobs:
   facebook_page:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      not(github.event.release.prerelease) &&
-      not(github.event.release.draft)
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: facebook-post-action
@@ -69,8 +69,8 @@ jobs:
   reddit:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      not(github.event.release.prerelease) &&
-      not(github.event.release.draft)
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: reddit
@@ -89,8 +89,8 @@ jobs:
   twitter:
     if: >-
       startsWith(github.repository, 'LizardByte/') &&
-      not(github.event.release.prerelease) &&
-      not(github.event.release.draft)
+      !github.event.release.prerelease &&
+      !github.event.release.draft
     runs-on: ubuntu-latest
     steps:
       - name: twitter


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Now that all repos are on pre-release logic, we can fix the release notifier to only send updates when a stable release is published. Editing from pre-release to non pre-release should trigger this workflow.

This hasn't run in a while, so it's unknown which ones still work... but in any event, this should be an improvement.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
