### PR TITLE
fix(codeql): use ucrt64 for msys2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -140,9 +140,12 @@ jobs:
           submodules: recursive
 
       - name: Setup msys2
-        if: runner.os == 'Windows'
+        if: >-
+          runner.os == 'Windows' &&
+          matrix.language == 'cpp'
         uses: msys2/setup-msys2@v2
         with:
+          msystem: ucrt64
           update: true
 
       # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use ucrt64 for codeql build when using msys2.

See: https://github.com/LizardByte/Sunshine/pull/2580


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
