### PR TITLE
fix(global-replicator): don't exlude all forks

### DIFF
--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -21,6 +21,15 @@ jobs:
   replicate:
     runs-on: ubuntu-latest
     name: Replicate files
+    env:
+      BOT_BRANCH_NAME: 'bot/update-files-from-global-repo'
+      COMMIT_MESSAGE: 'chore: update global workflows'
+      REPOS_TO_IGNORE: >-
+        homebrew-core,
+        winget-pkgs,
+        Virtual-Gamepad-Emulation-Bus,
+        Virtual-Gamepad-Emulation-Client,
+        Virtual-Gamepad-Emulation-dotnet
 
     steps:
       - name: Checkout repository
@@ -29,6 +38,9 @@ jobs:
       - name: Removing files
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -42,13 +54,10 @@ jobs:
             qodana-dotnet.yaml,
             qodana-js.yaml,
             qodana-python.yaml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: ''
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       # checkout between each step to ensure we have a clean GitHub workspace
       # see https://github.com/derberg/manage-files-in-multiple-repositories/issues/61#issuecomment-1747013728
@@ -58,6 +67,9 @@ jobs:
       - name: Replicating files (general)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -74,13 +86,10 @@ jobs:
             .github/workflows/issues.yml,
             .github/workflows/issues-stale.yml,
             .github/workflows/yaml-lint.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: ''
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -88,6 +97,9 @@ jobs:
       - name: Replicating files (python)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -95,13 +107,10 @@ jobs:
           patterns_to_include: >-
             .flake8,
             .github/workflows/python-flake8.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: 'python'
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -109,26 +118,29 @@ jobs:
       - name: Replicating files (docker)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
           patterns_to_ignore: ''
           patterns_to_include: >-
             .github/workflows/ci-docker.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: 'docker'
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Replicating files (docker)
+      - name: Replicating files (c, cpp)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -136,13 +148,10 @@ jobs:
           patterns_to_include: >-
             .clang-format,
             .github/workflows/cpp-lint.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
-          topics_to_include: 'cpp'
+          topics_to_include: 'c,cpp'
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -150,19 +159,19 @@ jobs:
       - name: Replicating files (custom issues)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
           patterns_to_ignore: ''
           patterns_to_include: >-
             .github/ISSUE_TEMPLATE/config.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: 'replicator-custom-issues'
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -170,6 +179,9 @@ jobs:
       - name: Replicating files (release/changelog workflows)
         uses: derberg/manage-files-in-multiple-repositories@v2.1.0
         with:
+          bot_branch_name: ${{ env.BOT_BRANCH_NAME }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
+          repos_to_ignore: ${{ env.REPOS_TO_IGNORE }}
           github_token: ${{ secrets.GH_BOT_TOKEN }}
           committer_username: ${{ secrets.GH_BOT_NAME }}
           committer_email: ${{ secrets.GH_BOT_EMAIL }}
@@ -177,31 +189,7 @@ jobs:
           patterns_to_include: >-
             .github/workflows/release-notifier.yml,
             .github/workflows/update-changelog.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
           topics_to_include: 'replicator-release-notifications'
           exclude_private: false
-          exclude_forked: true
+          exclude_forked: false
           destination: ''
-          bot_branch_name: bot/update-files-from-global-repo
-
-      # todo: the following can be removed after it has run once
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Removing files (changelog workflows)
-        uses: derberg/manage-files-in-multiple-repositories@v2.1.0
-        with:
-          github_token: ${{ secrets.GH_BOT_TOKEN }}
-          committer_username: ${{ secrets.GH_BOT_NAME }}
-          committer_email: ${{ secrets.GH_BOT_EMAIL }}
-          patterns_to_ignore: ''
-          patterns_to_remove: >-
-            .github/workflows/update-changelog.yml
-          commit_message: 'chore: update global workflows'
-          repos_to_ignore: ''
-          topics_to_include: 'github-action'
-          exclude_private: false
-          exclude_forked: true
-          destination: ''
-          bot_branch_name: bot/update-files-from-global-repo


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Don't exclude all forks by default. The list of excluded repos is now an env variable that will need to be udpated if/when new forks are added.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
