### PR TITLE
fix(release_notifier): ensure github output can take multline strings

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -19,7 +19,7 @@ jobs:
       !github.event.release.prerelease &&
       !github.event.release.draft
     outputs:
-      simplified_body: ${{ steps.output.outputs.simplified_body }}
+      SIMPLIFIED_BODY: ${{ steps.output.outputs.SIMPLIFIED_BODY }}
     runs-on: ubuntu-latest
     steps:
       - name: remove contributors section
@@ -30,7 +30,11 @@ jobs:
           echo "${RELEASE_BODY}" > ./release_body.md
           modified_body=$(sed '/^---$/d; /^## Contributors$/,/<\/a>/d' ./release_body.md)
           echo "modified_body: ${modified_body}"
-          echo "simplified_body=${modified_body}" >> $GITHUB_OUTPUT
+
+          # use a heredoc to ensure the output is multiline
+          echo "SIMPLIFIED_BODY<<EOF" >> $GITHUB_OUTPUT
+          echo "${modified_body}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
   discord:
     if: >-
@@ -45,7 +49,7 @@ jobs:
         with:
           avatar_url: ${{ secrets.ORG_LOGO_URL }}
           color: 0x00ff00
-          description: ${{ needs.simplified_changelog.outputs.simplified_body }}
+          description: ${{ needs.simplified_changelog.outputs.SIMPLIFIED_BODY }}
           nodetail: true
           nofail: false
           title: ${{ github.event.repository.name }} ${{ github.ref_name }} Released
@@ -104,7 +108,7 @@ jobs:
           title: ${{ github.event.repository.name }} ${{ github.ref_name }} Released
           url: ${{ github.event.release.html_url }}
           flair-id: ${{ secrets.REDDIT_FLAIR_ID }}  # https://www.reddit.com/r/<subreddit>>/api/link_flair.json
-          comment: ${{ needs.simplified_changelog.outputs.simplified_body }}
+          comment: ${{ needs.simplified_changelog.outputs.SIMPLIFIED_BODY }}
 
   x:
     if: >-


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use a heredoc to ensure the simplified changelog body is able to be set as an output.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
