### PR TITLE
fix: run stale issues check under strategy matrix

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 ---
-# This action is centrally managed in https://github.com/<organization>/.github/
+# This file is centrally managed in https://github.com/<organization>/.github/
 # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
 # the above-mentioned repo.
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 ---
-# This action is centrally managed in https://github.com/<organization>/.github/
+# This file is centrally managed in https://github.com/<organization>/.github/
 # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
 # the above-mentioned repo.
 

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,5 +1,5 @@
 ---
-# This action is centrally managed in https://github.com/<organization>/.github/
+# This file is centrally managed in https://github.com/<organization>/.github/
 # Don't make changes to this file in this repo as they will be overwritten with changes made to the same file in
 # the above-mentioned repo.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,9 +25,3 @@
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
-
-## Branch Updates
-LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
-must be updated before it can be merged. You must also
-[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
-- [ ] I want maintainers to keep my branch updated

--- a/.github/workflows/global-replicator.yml
+++ b/.github/workflows/global-replicator.yml
@@ -52,6 +52,7 @@ jobs:
             .github/workflows/autoupdate-labeler.yml,
             .github/workflows/ci-qodana.yml,
             .github/workflows/dispatcher.yml,
+            .github/workflows/issues-stale.yml,
             .github/workflows/pull-requests.yml,
             qodana-dotnet.yaml,
             qodana-js.yaml,
@@ -86,7 +87,6 @@ jobs:
             .github/workflows/autoupdate-labeler.yml,
             .github/workflows/codeql.yml,
             .github/workflows/issues.yml,
-            .github/workflows/issues-stale.yml,
             .github/workflows/yaml-lint.yml
           topics_to_include: ''
           exclude_private: false

--- a/.github/workflows/issues-stale.yml
+++ b/.github/workflows/issues-stale.yml
@@ -10,15 +10,56 @@ name: Stale Issues / PRs
 on:
   schedule:
     - cron: '00 10 * * *'
+  workflow_dispatch:
 
 jobs:
-  stale:
-    name: Check Stale Issues / PRs
-    if: startsWith(github.repository, 'LizardByte/')
+  setup-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.result }}
+    steps:
+      # get all repos in this org
+      - name: Get repos
+        id: set-matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const opts = github.rest.repos.listForOrg.endpoint.merge({ org: context.repo.owner });
+            const repos = await github.paginate(opts)
+
+            // create a GitHub strategy matrix
+            let matrix = { "include": [] };
+            for (const repo of repos) {
+              matrix.include.push({ "repo": repo.name });
+            }
+            return matrix
+
+  test-matrix:
+    if: github.event_name == 'workflow_dispatch'
+    name: Test Matrix - ${{ matrix.repo }}
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+    steps:
+      - name: Test Matrix
+        run: echo ${{ matrix.repo }}
+
+  stale:
+    if: github.event_name == 'schedule'
+    name: Check Stale Issues / PRs
+    needs: setup-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup-matrix.outputs.matrix) }}
+      max-parallel: 1  # run one at a time to attempt to avoid GitHub api rate limits
     steps:
       - name: Stale
-        uses: actions/stale@v9
+        # TODO: use official action after https://github.com/actions/stale/pull/1081 is merged
+        # uses: actions/stale@v9
+        uses: amenocal/stale@44df11e9a0d1acc948e6c4c610ca486edeb1b16a
         with:
           close-issue-message: >
             This issue was closed because it has been stalled for 10 days with no activity.
@@ -27,8 +68,9 @@ jobs:
           days-before-stale: 90
           days-before-close: 10
           exempt-all-assignees: true
-          exempt-issue-labels: 'added,fixed'
           exempt-pr-labels: 'dependencies,l10n'
+          repo-owner: ${{ github.repository_owner }}
+          repo-name: ${{ matrix.repo }}
           stale-issue-label: 'stale'
           stale-issue-message: >
             It seems this issue hasn't had any activity in the past 90 days.
@@ -40,22 +82,4 @@ jobs:
             If it's still something you're working on or would like to pursue,
             please leave a comment or update your branch.
             Otherwise, we'll be closing this PR in 10 days to reduce our backlog. Thanks!
-          repo-token: ${{ secrets.GH_BOT_TOKEN }}
-
-      - name: Invalid Template
-        uses: actions/stale@v9
-        with:
-          close-issue-message: >
-            This issue was closed because the the template was not completed after 5 days.
-          close-pr-message: >
-            This PR was closed because the the template was not completed after 5 days.
-          days-before-stale: 0
-          days-before-close: 5
-          only-labels: 'invalid:template-incomplete'
-          stale-issue-label: 'invalid:template-incomplete'
-          stale-issue-message: >
-            Invalid issues template.
-          stale-pr-label: 'invalid:template-incomplete'
-          stale-pr-message: >
-            Invalid PR template.
           repo-token: ${{ secrets.GH_BOT_TOKEN }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Run stale issues workflow under a matrix. This PR will remove that workflow from every individual repo in the org, and instead run it from this repo.

Also:

- updates PR template
- a few comments are fixed


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
