### PR TITLE
docs: use myst-parser for markdown

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 furo==2024.8.6
-m2r2==0.3.3.post2
+myst-parser==4.0.0
 rstcheck[sphinx]==6.2.4
 rstfmt==0.0.14
 Sphinx==7.2.6

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ if script_dir:
 
 # -- Project information -----------------------------------------------------
 project = 'LizardByte'
-copyright = f'{datetime.now ().year}, {project}'
+project_copyright = f'{datetime.now ().year}, {project}'
 author = 'ReenigneArcher'
 
 # The full version, including alpha/beta/rc tags
@@ -37,7 +37,7 @@ version = version.version
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'm2r2',  # enable markdown files
+    'myst_parser',  # enable markdown files
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.todo',  # enable to-do sections
     'sphinx.ext.viewcode',  # add links to view source code
@@ -53,7 +53,10 @@ extensions = [
 exclude_patterns = ['toc.rst']
 
 # Extensions to include.
-source_suffix = ['.rst', '.md']
+source_suffix = {
+    '.rst': 'restructuredtext',
+    '.md': 'markdown',
+}
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/source/developers/code_of_conduct.rst
+++ b/docs/source/developers/code_of_conduct.rst
@@ -1,1 +1,2 @@
-.. mdinclude:: ../../../CODE_OF_CONDUCT.md
+.. include:: ../../../CODE_OF_CONDUCT.md
+   :parser: myst_parser.docutils_


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Use myst-parser instead of m2r2 for markdown files in docs. m2r2 is no longer maintained, see https://github.com/CrossNox/m2r2/issues/68

Todo:
- [ ] Use this in other repos that use m2r2


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
