### PR TITLE
fix(releases): properly name blog post files

### DIFF
--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -70,7 +70,17 @@ jobs:
           tag_name="${{ github.event.release.tag_name }}"
           semver="${tag_name#v}"
           repo_lower="$(echo "${{ github.event.repository.name }}" | tr '[:upper:]' '[:lower:]')"
-          file_name="_posts/releases/${repo_lower}/${semver//./-}.md"
+
+          # extract year, month, and day
+          year="${semver%%.*}"
+          month_day="${semver#*.}"
+          month_day="${month_day%%.*}"
+
+          # ensure month_day is 4 digits
+          month_day=$(printf "%04d" "$month_day")
+
+          # create the filename
+          file_name="_posts/releases/${year}-${month_day:0:2}-${month_day:2:2}-v${semver}.md"
           mkdir -p "$(dirname "${file_name}")"
 
           # create jekyll blog post


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Jekyll blog posts need to be named like `YYYY-MM-DD-<anything>.md`. The previous code assumed the semver was separated by year, month, and day, but it is not.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
