### PR TITLE
docs(security): add href for security tab

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ LizardByte only supports the latest version of our software.
 
 ## Reporting a Vulnerability
 
-If you think you have found a security vulnerability in our software, please report it to us using the "Security" tab
-on the GitHub repository.
+If you think you have found a security vulnerability in our software, please report it to us at
+<a href="../../security">Security</a>.
 
 After you have submitted the vulnerability, we will review the report internally and respond to you with
 any questions or next steps.


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
These PR adds an href to the security tab of the current repo. We need to navigate up two directories or else GitHub resolves it to the blob url (which doesn't actually exist). 


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
