### PR TITLE
ci(docker): increase permissions and bump release actions

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -114,6 +114,8 @@ jobs:
       release_generate_release_notes: ${{ steps.setup_release.outputs.release_generate_release_notes }}
       release_tag: ${{ steps.setup_release.outputs.release_tag }}
       release_version: ${{ steps.setup_release.outputs.release_version }}
+    permissions:
+      contents: write  # read does not work to check squash and merge details
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -121,7 +123,7 @@ jobs:
 
       - name: Setup Release
         id: setup_release
-        uses: LizardByte/setup-release-action@v2025.102.14715
+        uses: LizardByte/setup-release-action@v2025.426.225
         with:
           dotnet: ${{ needs.check_dockerfiles.outputs.dotnet }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -354,7 +356,7 @@ jobs:
         if: >
           needs.setup_release.outputs.publish_release == 'true' &&
           steps.prepare.outputs.artifacts == 'true'
-        uses: LizardByte/create-release-action@v2025.102.13208
+        uses: LizardByte/create-release-action@v2025.426.1549
         with:
           allowUpdates: true
           artifacts: "*artifacts/*"


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
`setup-release-action` needs `write` permission.

For some reason the GITHUB_TOKEN cannot read repository metadata with `contents: read` even though the job indicates that it can read metadata. I guess that the keys needed are available only to users with elevated permissions.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
