### PR TITLE
docs(deps): switch back to m2r2 for markdown

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 furo==2024.8.6
-myst-parser==4.0.1
+m2r2==0.3.4
 rstcheck[sphinx]==6.2.4
 rstfmt==0.0.14
 Sphinx==8.2.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,7 +32,7 @@ version = os.getenv('READTHEDOCS_VERSION', 'latest')
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'myst_parser',  # enable markdown files
+    'm2r2',  # enable markdown files
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.todo',  # enable to-do sections
     'sphinx.ext.viewcode',  # add links to view source code

--- a/docs/source/developers/code_of_conduct.rst
+++ b/docs/source/developers/code_of_conduct.rst
@@ -1,2 +1,1 @@
-.. include:: ../../../CODE_OF_CONDUCT.md
-   :parser: myst_parser.docutils_
+.. mdinclude:: ../../../CODE_OF_CONDUCT.md

--- a/docs/source/developers/contributing.rst
+++ b/docs/source/developers/contributing.rst
@@ -1,2 +1,1 @@
-.. include:: ../../../CONTRIBUTING.md
-   :parser: myst_parser.docutils_
+.. mdinclude:: ../../../CONTRIBUTING.md


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Try m2r2 again now that https://github.com/CrossNox/m2r2/issues/68 is resolved.

Edit: There is zero difference in the rendered output, so closing for now.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
