### PR TITLE
fix(docker): move update dockerhub readme to separate job

### DIFF
--- a/.github/workflows/__call-docker.yml
+++ b/.github/workflows/__call-docker.yml
@@ -105,8 +105,16 @@ jobs:
           echo $matrix
           echo $matrix | jq .
           echo "matrix=$matrix" >> $GITHUB_OUTPUT
+      - name: Additional Outputs
+        id: additional_outputs
+        run: |
+          # set outputs for later jobs
+          REPOSITORY=${{ github.repository }}
+          BASE_TAG=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')
+          echo "base_tag=${BASE_TAG}" >> $GITHUB_OUTPUT
 
     outputs:
+      base_tag: ${{ steps.additional_outputs.outputs.base_tag }}
       dockerfiles: ${{ steps.find.outputs.dockerfiles }}
       matrix: ${{ steps.find.outputs.matrix }}
 
@@ -167,8 +175,7 @@ jobs:
           fi
 
           # setup the tags
-          REPOSITORY=${{ github.repository }}
-          BASE_TAG=$(echo $REPOSITORY | tr '[:upper:]' '[:lower:]')
+          BASE_TAG="${{ needs.check_dockerfiles.outputs.base_tag }}"
 
           TAGS="${BASE_TAG}:${COMMIT:0:7}${{ matrix.tag }},ghcr.io/${BASE_TAG}:${COMMIT:0:7}${{ matrix.tag }}"
 
@@ -313,14 +320,28 @@ jobs:
           path: artifacts/
           if-no-files-found: error
 
+  release:
+    name: Release
+    if: >
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    needs:
+      - check_dockerfiles
+      - docker
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            DOCKER_README.md
+          sparse-checkout-cone-mode: false
+
       - name: Update Docker Hub Description
-        if: >
-          github.event_name == 'push' &&
-          github.ref == 'refs/heads/master'
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}  # token is not currently supported
-          repository: ${{ env.BASE_TAG }}
+          repository: ${{ needs.check_dockerfiles.outputs.base_tag }}
           short-description: ${{ github.event.repository.description }}
           readme-filepath: ./DOCKER_README.md


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Move update dockerhub readme to separate job
- Fix `BASE_TAG` env variable not being set


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Resolves https://github.com/LizardByte/roadmap/issues/91


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
